### PR TITLE
Add TG:GetQuestLogIndexByID. Partly revert bab3024

### DIFF
--- a/Broker.lua
+++ b/Broker.lua
@@ -144,7 +144,7 @@ function dataobj.OnClick(self, btn)
 		else
 			if IsShiftKeyDown() then TourGuide:SetTurnedIn()
 			else
-				local i = GetQuestLogIndexByID(TourGuide:GetObjectiveTag("QID", TourGuide.current))
+				local i = self:GetQuestLogIndexByID(TourGuide:GetObjectiveTag("QID", TourGuide.current))
 				if i then SelectQuestLogEntry(i) end
 				ShowUIPanel(QuestLogFrame)
 			end

--- a/TourGuide.lua
+++ b/TourGuide.lua
@@ -152,11 +152,15 @@ function TourGuide:GetQuestLogIndexByName(name)
 	end
 end
 
+function TourGuide:GetQuestLogIndexByID(qid)
+	local index = GetQuestLogIndexByID(qid)
+	if (index > 0) then return index end
+end
 
 function TourGuide:GetQuestDetails(name, qid, qo)
 	if not name then return end
 
-	local i = qid and GetQuestLogIndexByID(qid) or self:GetQuestLogIndexByName(name)
+	local i = qid and self:GetQuestLogIndexByID(qid) or self:GetQuestLogIndexByName(name)
 	local complete = i and (qo and self:IsQuestObjectiveComplete(i, qo) or select(6, GetQuestLogTitle(i)) == 1)
 	return i, complete
 end


### PR DESCRIPTION
TourGuide:GetQuestLogIndexByID originally returned either index (i.e. number) or nil. WoW's API returns 0 if the quest is not found which breaks all the checks included in the program (because unlike many other programming languages, like C, 0 is considered true and only nil or false are actually false)

We could convert all of those checks into val > 0 checks, but I thought that adding a function that mimics the original intent is an easier fix.

I think this will fix most of the issues we are having currently.

Thoughts?