### PR TITLE
Fix for Non-Quest Left Click Action

### DIFF
--- a/Broker.lua
+++ b/Broker.lua
@@ -144,6 +144,8 @@ function dataobj.OnClick(self, btn)
 		else
 			if IsShiftKeyDown() then TourGuide:SetTurnedIn()
 			else
+				if (TourGuide:GetObjectiveTag("QID", TourGuide.current) == nil) then return end
+
 				local i = TourGuide:GetQuestLogIndexByID(TourGuide:GetObjectiveTag("QID", TourGuide.current))
 				if i then SelectQuestLogEntry(i) end
 				ShowUIPanel(QuestLogFrame)

--- a/TourGuide_Alliance/12_17_Darkshore.lua
+++ b/TourGuide_Alliance/12_17_Darkshore.lua
@@ -1,7 +1,7 @@
 
 TourGuide:RegisterGuide("Darkshore (12-17)", "Loch Modan (17-18)", "Alliance", function()
 return [[
-b Auberdine |N|Take the boat from Stormwind or fly from Teldrassil|
+b Auberdine |N|Fly from Teldrassil or Boat from Menethil Harbor to Darnassus|
 
 A Washed Ashore (Part 1) |QID|3524|
 T Flight to Auberdine |R|Night Elf| |QID|6342|


### PR DESCRIPTION
When you click on something that is not an actual quest you would get a nil error value by the function, so it throws an error looking up a nil quest id.